### PR TITLE
feat: buscando filmes no cache antes de fazer requisicao

### DIFF
--- a/src/services/movies.ts
+++ b/src/services/movies.ts
@@ -7,7 +7,7 @@ import type {
   MoviesResponse,
 } from "@/types/types";
 import { useMovieStore } from "@/stores/movies";
-import { getFromCache, saveToCache } from "@/utils/movieCache";
+import { getFromCache, getMovieById, saveToCache } from "@/utils/movieCache";
 
 export async function getPopularMovies(page: number  = 1): Promise<Movie[]> {
   const res: AxiosResponse<MoviesResponse> = await api.get("/movie/popular", {
@@ -49,12 +49,14 @@ export async function getAllGenres(): Promise<void> {
 }
 
 export async function getMovieDetails(id: number): Promise<Movie> {
-  const res: AxiosResponse<Movie> = await api.get(
-    `/movie/${id}`,
-    {
-      params: { language: "pt-BR" },
-    }
-  );
+  const cachedMovie = getMovieById(id);
+  if (cachedMovie) {
+    return cachedMovie;
+  }
+
+  const res: AxiosResponse<Movie> = await api.get(`/movie/${id}`, {
+    params: { language: "pt-BR" },
+  });
   return res.data;
 }
 

--- a/src/utils/movieCache.ts
+++ b/src/utils/movieCache.ts
@@ -77,3 +77,15 @@ export function saveToCache(
 
   saveCache(data);
 }
+
+export function getMovieById(id: number): Movie | null {
+  const cacheData = loadCache();
+
+  for (const pageKey of Object.keys(cacheData.cache)) {
+    const page = cacheData.cache[pageKey];
+    const found = page?.movies.find((movie) => movie.id === id);
+    if (found) return found;
+  }
+
+  return null;
+}


### PR DESCRIPTION
a pagina de detalhes dos filmes por padrão faz uma requisição a API para pegar os dados dos filmes, agora há uma validação para investigar se já tem os detalhes deste filme armazenado no cache do navegador